### PR TITLE
Fix controls being reset when starting the game

### DIFF
--- a/autoload/globals.gd
+++ b/autoload/globals.gd
@@ -157,7 +157,6 @@ func load_controls(config_filepath='user://keybinds.ini'):
 					controller_controls[key] = value
 			else:
 				controller_controls[key] = null
-	save_controls()
 
 func load_default_controls():
 #	for key in configurable_keys:


### PR DESCRIPTION
For some reason the `load_controls` function called `save_controls()`.

To make contributions like this possible you should [add an open-source license to this repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/licensing-a-repository). Godot uses the MIT license for example. 